### PR TITLE
Add global release notes template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  exclude:
+    authors:
+      - knative-automation
+  categories:
+    - title: 🚨 Breaking or Notable Changes
+      labels:
+        - kind/api-change
+        - kind/deprecation
+        - kind/removal
+        - kind/security
+    - title: 💫 New Features & Enhancements
+      labels:
+        - kind/feature
+        - kind/enhancement
+    - title: 🐞 Bug Fixes
+      labels:
+        - kind/bug
+    - title: 🛠 Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,7 @@
 changelog:
   exclude:
     authors:
+      - dependabot
       - knative-automation
   categories:
     - title: 🚨 Breaking or Notable Changes


### PR DESCRIPTION
# Changes


- :gift: Add global release notes template

The format is a merge between our common templates we use in release blog and k8s release-notes tool we used so far. 

With the template in place, release leads don't have to execute GH action to produce release notes in `.md` and copy it over. Rather press `Generate release notes` button in release edit view.
Future enhancement to consider, the process can be further automated with GH API calls, it's not 1 step process, but rather a chain. In a nutshell POST to generate notes with inputs -> content in response -> POST to edit/update release body. 


/cc @knative/knative-release-leads 
/cc @knative/technical-oversight-committee 

Fixes https://github.com/knative/community/issues/1499

Based on  docs:
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configurations

Preview from knative/client current `main`:


![Screenshot 2024-07-17 at 14 24 00](https://github.com/user-attachments/assets/6182b20f-b2a3-4107-9c09-4162ea72bb99)


Preview in markdown format:
```
<!-- Release notes generated using configuration in .github/release.yml at main -->
## What's Changed
### 💫 New Features & Enhancements
* Add option flags to define nodeSelector, nodeAffinity and toleration on Knative Service by @Shashankft9 in https://github.com/knative/client/pull/1924
### 🛠 Other Changes
* Add release note template by @dsimansk in https://github.com/knative/client/pull/1956

## New Contributors
* @Shashankft9 made their first contribution in https://github.com/knative/client/pull/1924

**Full Changelog**: https://github.com/knative/client/compare/knative-v1.14.0...v0.0.1-release-notes
```